### PR TITLE
Ownertype removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: objective-c
+language: swift
 xcode_workspace: Example/Coherence.xcworkspace
 xcode_scheme: Coherence-Example
 osx_image: xcode7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: swift
 xcode_workspace: Example/Coherence.xcworkspace
 xcode_scheme: Coherence-Example
 osx_image: xcode7.1
-sudo: false
+sudo: true
 
 before_install:
 - brew install xctool

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: swift
 xcode_workspace: Example/Coherence.xcworkspace
 xcode_scheme: Coherence-Example
 osx_image: xcode7.1
+sudo: false
 
 before_install:
 - brew install xctool

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: swift
+language: objective-c
 xcode_workspace: Example/Coherence.xcworkspace
 xcode_scheme: Coherence-Example
 osx_image: xcode7.1

--- a/Coherence.podspec
+++ b/Coherence.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Coherence"
-  s.version          = "0.4.0"
+  s.version          = "0.4.1"
   s.summary          = "Coherence"
   s.description      = <<-DESC
                        Coherence is a collection of base frameworks that help set the groundwork for module development.

--- a/Example/Coherence.xcodeproj/xcshareddata/xcschemes/Coherence-Example.xcscheme
+++ b/Example/Coherence.xcodeproj/xcshareddata/xcschemes/Coherence-Example.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Coherence (0.4.0):
-    - Coherence/No-Arc (= 0.4.0)
+  - Coherence (0.4.1):
+    - Coherence/No-Arc (= 0.4.1)
     - TraceLog/ObjC (~> 0.4)
     - TraceLog/Swift (~> 0.4)
-  - Coherence/No-Arc (0.4.0):
+  - Coherence/No-Arc (0.4.1):
     - TraceLog/ObjC (~> 0.4)
     - TraceLog/Swift (~> 0.4)
   - TraceLog/Core (0.4.5)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Coherence: 3566189b60fa3c74a98406a4cd1258c86463d665
+  Coherence: c5ce72a6df1a0b5ebd89f945db5fa50237f5f85b
   TraceLog: 5142132741f8e70dc3ae5aef61657dd4e6d55bb0
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Local Podspecs/Coherence.podspec.json
+++ b/Example/Pods/Local Podspecs/Coherence.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Coherence",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "summary": "Coherence",
   "description": "Coherence is a collection of base frameworks that help set the groundwork for module development.",
   "homepage": "https://github.com/tonystone/coherence",
@@ -8,7 +8,7 @@
   "authors": "Tony Stone",
   "source": {
     "git": "https://github.com/tonystone/coherence.git",
-    "tag": "0.4.0"
+    "tag": "0.4.1"
   },
   "platforms": {
     "ios": "8.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Coherence (0.4.0):
-    - Coherence/No-Arc (= 0.4.0)
+  - Coherence (0.4.1):
+    - Coherence/No-Arc (= 0.4.1)
     - TraceLog/ObjC (~> 0.4)
     - TraceLog/Swift (~> 0.4)
-  - Coherence/No-Arc (0.4.0):
+  - Coherence/No-Arc (0.4.1):
     - TraceLog/ObjC (~> 0.4)
     - TraceLog/Swift (~> 0.4)
   - TraceLog/Core (0.4.5)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Coherence: 3566189b60fa3c74a98406a4cd1258c86463d665
+  Coherence: c5ce72a6df1a0b5ebd89f945db5fa50237f5f85b
   TraceLog: 5142132741f8e70dc3ae5aef61657dd4e6d55bb0
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -600,7 +600,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -727,7 +727,6 @@
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Pods_Tests;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -758,7 +757,6 @@
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Pods_Coherence;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -789,7 +787,6 @@
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Pods_Coherence;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -818,7 +815,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -858,7 +854,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/Coherence/Coherence.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Coherence;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -889,7 +884,6 @@
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Pods_Tests;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -918,7 +912,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/TraceLog/TraceLog.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = TraceLog;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -946,7 +939,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/TraceLog/TraceLog.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = TraceLog;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -975,7 +967,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/Coherence/Coherence.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Coherence;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Coherence.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Coherence.xcscheme
@@ -1,39 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForArchiving = "YES">
             <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "90FA9F97413364FCAB46769147D5929F"
-               BuildableName = "Coherence.framework"
-               BlueprintName = "Coherence"
-               ReferencedContainer = "container:Pods.xcodeproj">
+               BuildableIdentifier = 'primary'
+               BlueprintIdentifier = '66F7FD40275205C32A9A38E2'
+               BlueprintName = 'Coherence'
+               ReferencedContainer = 'container:Pods.xcodeproj'
+               BuildableName = 'Coherence.framework'>
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -41,25 +38,17 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "90FA9F97413364FCAB46769147D5929F"
-            BuildableName = "Coherence.framework"
-            BlueprintName = "Coherence"
-            ReferencedContainer = "container:Pods.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "YES"
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/Pods/Target Support Files/Coherence/Info.plist
+++ b/Example/Pods/Target Support Files/Coherence/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.4.1</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/Pods-Coherence/Info.plist
+++ b/Example/Pods/Target Support Files/Pods-Coherence/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/Pods-Tests/Info.plist
+++ b/Example/Pods/Target Support Files/Pods-Tests/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/TraceLog/Info.plist
+++ b/Example/Pods/Target Support Files/TraceLog/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>0.4.5</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.4.5</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/Pod/Cache/CoreDataStack.swift
+++ b/Pod/Cache/CoreDataStack.swift
@@ -12,7 +12,7 @@ import TraceLog
 
 @objc public final class CoreDataStack : NSObject  {
     
-    private typealias CoreDataStackType = GenericCoreDataStack<CoreDataStack,NSPersistentStoreCoordinator, NSManagedObjectContext>
+    private typealias CoreDataStackType = GenericCoreDataStack<NSPersistentStoreCoordinator, NSManagedObjectContext>
     
     private let impl: CoreDataStackType!   // Note: this is protected with a guard in the designated init method
     
@@ -20,22 +20,19 @@ import TraceLog
         Initializes the receiver with a managed object model.
     
         - Parameter managedObjectModel: A managed object model.
-    
-        - Returns: The receiver, initialized with model.
     */
     public init?(managedObjectModel model: NSManagedObjectModel) {
-        impl = CoreDataStackType(managedObjectModel: model)
+        impl = CoreDataStackType(managedObjectModel: model, logTag: String(CoreDataStack.self))
     }
     
     /**
         Initializes the receiver with a managed object model.
      
         - Parameter managedObjectModel: A managed object model.
-     
-        - Returns: The receiver, initialized with model.
+        - configurationOptions: Optional configuration settings by persistent store config name (see ConfigurationOptionsType for structure)
      */
-    public init?(managedObjectModel model: NSManagedObjectModel, configurationOptions: ConfigurationOptionsType) {
-        impl = CoreDataStackType(managedObjectModel: model, configurationOptions: configurationOptions)
+    public init?(managedObjectModel model: NSManagedObjectModel, configurationOptions options: ConfigurationOptionsType) {
+        impl = CoreDataStackType(managedObjectModel: model, configurationOptions: options, logTag: String(CoreDataStack.self))
     }
     
     public func mainThreadContext () -> NSManagedObjectContext {

--- a/Pod/Cache/Internal/Meta/WriteAheadLog.swift
+++ b/Pod/Cache/Internal/Meta/WriteAheadLog.swift
@@ -35,7 +35,7 @@ internal let metaModel           = MetaModel()
 
 internal class WriteAheadLog {
 
-    private typealias CoreDataStackType = GenericCoreDataStack<WriteAheadLog, NSPersistentStoreCoordinator, NSManagedObjectContext>
+    private typealias CoreDataStackType = GenericCoreDataStack<NSPersistentStoreCoordinator, NSManagedObjectContext>
     
     private let coreDataStack: CoreDataStackType!
     
@@ -47,7 +47,7 @@ internal class WriteAheadLog {
             "Initializing instance..."
         }
         
-        coreDataStack = CoreDataStackType(managedObjectModel: metaModel, namingPrefix: "meta")
+        coreDataStack = CoreDataStackType(managedObjectModel: metaModel, namingPrefix: "meta", logTag: String(WriteAheadLog.self))
         
         guard coreDataStack != nil else {
             return nil


### PR DESCRIPTION
### Update GenericCoreDataStack.swift …
- Removed ownerType template parameter and moved it to a tag param on the init.
- Added internal parameter names to init configurationOptions and namingPrefix.
- Added initial class comment header and init header
### Misc
- Updated CoreDataStack.swift to comply with GenericCoreDataStacks new definition.
- Updated WriteAheadLog.swift to comply with GenericCoreDataStacks new definition.
- Updated Coherence.podspec version for release 0.4.1.
- Ran "pod update" to update project files with new version number.
