### PR TITLE
Adding increased coverage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ All significant changes to this project will be documented in this file.
 - This CHANGELOG.md file.
 
 #### Updated
-- Changed from Swift 2.0 to Swift 3
-- Changed from CocoaPods 0.39.0 to 1.1.0
+- Changed from Swift 2.0 to Swift 3.
+- Changed from CocoaPods 0.39.0 to 1.1.0.
 - Change CoreDataStack init methods to throw instead of be failable.
-- Changed to TraceLog 2.0
+- Changed default Info.plist key to CCCOnfiguration.
+- Changed CCOverwriteIncompatibleStore to overwriteIncompatibleStore
+- Changed to TraceLog 2.0.
 
 #### Removed
 - Removed PersistentStoreCoordinator until the remainder of the implementation is complete.

--- a/Example/Coherence.xcodeproj/project.pbxproj
+++ b/Example/Coherence.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		EACAA3F31DC6D1DF00D3D371 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACAA3F01DC6D1DF00D3D371 /* User.swift */; };
 		EACAA3F41DC6D1DF00D3D371 /* User+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACAA3F11DC6D1DF00D3D371 /* User+CoreDataProperties.swift */; };
 		EACAA3F61DC6D22D00D3D371 /* TestModel1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACAA3F51DC6D22D00D3D371 /* TestModel1.swift */; };
+		EACAA3F91DC7E9E300D3D371 /* GenericCoreDataStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACAA3F81DC7E9E300D3D371 /* GenericCoreDataStackTests.swift */; };
+		EACAA3FB1DC8114F00D3D371 /* CoherenceTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACAA3FA1DC8114F00D3D371 /* CoherenceTestUtilities.swift */; };
+		EACAA3FD1DC84EEB00D3D371 /* TestModel3.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACAA3FC1DC84EEB00D3D371 /* TestModel3.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -81,6 +84,9 @@
 		EACAA3F11DC6D1DF00D3D371 /* User+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		EACAA3F51DC6D22D00D3D371 /* TestModel1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestModel1.swift; sourceTree = "<group>"; };
 		EACAA3F71DC6E85400D3D371 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
+		EACAA3F81DC7E9E300D3D371 /* GenericCoreDataStackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericCoreDataStackTests.swift; sourceTree = "<group>"; };
+		EACAA3FA1DC8114F00D3D371 /* CoherenceTestUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoherenceTestUtilities.swift; sourceTree = "<group>"; };
+		EACAA3FC1DC84EEB00D3D371 /* TestModel3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestModel3.swift; sourceTree = "<group>"; };
 		EAE527531DC4E94F00AA65AE /* codecov.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = codecov.yml; path = ../codecov.yml; sourceTree = "<group>"; };
 		F8F8D94FABCD9BFC28AEADDF /* Coherence.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Coherence.podspec; path = ../Coherence.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
@@ -236,11 +242,14 @@
 			children = (
 				EACAA3E51DC6CDCD00D3D371 /* ConfigurationTests.swift */,
 				EACAA3E61DC6CDCD00D3D371 /* CoreDataStackTests.swift */,
+				EACAA3F81DC7E9E300D3D371 /* GenericCoreDataStackTests.swift */,
 				EACAA3F51DC6D22D00D3D371 /* TestModel1.swift */,
 				EACAA3E71DC6CDCD00D3D371 /* TestModel2.swift */,
+				EACAA3FC1DC84EEB00D3D371 /* TestModel3.swift */,
 				EACAA3F01DC6D1DF00D3D371 /* User.swift */,
 				EACAA3F11DC6D1DF00D3D371 /* User+CoreDataProperties.swift */,
 				EABEDD251DC6732700D5785D /* SimpleEntity.swift */,
+				EACAA3FA1DC8114F00D3D371 /* CoherenceTestUtilities.swift */,
 			);
 			path = CoherenceTests;
 			sourceTree = "<group>";
@@ -472,10 +481,13 @@
 				EACAA3EA1DC6CDCD00D3D371 /* TestModel2.swift in Sources */,
 				EABEDD381DC6732700D5785D /* SimpleEntity.swift in Sources */,
 				EACAA3F61DC6D22D00D3D371 /* TestModel1.swift in Sources */,
+				EACAA3FB1DC8114F00D3D371 /* CoherenceTestUtilities.swift in Sources */,
 				EACAA3ED1DC6CDE800D3D371 /* CCConfigurationTests.m in Sources */,
 				EACAA3E81DC6CDCD00D3D371 /* ConfigurationTests.swift in Sources */,
 				EACAA3F31DC6D1DF00D3D371 /* User.swift in Sources */,
+				EACAA3F91DC7E9E300D3D371 /* GenericCoreDataStackTests.swift in Sources */,
 				EACAA3E91DC6CDCD00D3D371 /* CoreDataStackTests.swift in Sources */,
+				EACAA3FD1DC84EEB00D3D371 /* TestModel3.swift in Sources */,
 				EACAA3F41DC6D1DF00D3D371 /* User+CoreDataProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Coherence/Coherence-Info.plist
+++ b/Example/Coherence/Coherence-Info.plist
@@ -2,6 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CCConfiguration</key>
+	<dict>
+		<key>boolProperty</key>
+		<true/>
+		<key>charProperty</key>
+		<integer>65</integer>
+		<key>doubleProperty</key>
+		<real>12345.67</real>
+		<key>floatProperty</key>
+		<real>12345.67</real>
+		<key>integerProperty</key>
+		<string>12345</string>
+		<key>stringProperty</key>
+		<string>String test value</string>
+		<key>unsignedIntegerProperty</key>
+		<integer>12345</integer>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -24,23 +41,6 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>TCCConfiguration</key>
-	<dict>
-		<key>boolProperty</key>
-		<true/>
-		<key>charProperty</key>
-		<integer>65</integer>
-		<key>doubleProperty</key>
-		<real>12345.67</real>
-		<key>floatProperty</key>
-		<real>12345.67</real>
-		<key>integerProperty</key>
-		<string>12345</string>
-		<key>stringProperty</key>
-		<string>String test value</string>
-		<key>unsignedIntegerProperty</key>
-		<integer>12345</integer>
-	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile</key>

--- a/Sources/Coherence/Configuration.swift
+++ b/Sources/Coherence/Configuration.swift
@@ -20,7 +20,7 @@
 import TraceLog
 
 // Default values for override methods
-public let defaultBundleKey = "TCCConfiguration"
+public let defaultBundleKey = "CCConfiguration"
 public let defaultDefaults  = [String: AnyObject]()
 
 /**

--- a/Sources/Coherence/GenericCoreDataStack.swift
+++ b/Sources/Coherence/GenericCoreDataStack.swift
@@ -33,7 +33,7 @@ public let defaultModelConfigurationName: String = "PF_DEFAULT_CONFIGURATION_NAM
     An option – when set to true – will check if the persistent store and the model are incompatible.
     If so, the underlying persistent store will be removed and replaced.
  */
-public let OverwriteIncompatibleStoreOption: String = "overwriteIncompatibleStoreOption"
+public let overwriteIncompatibleStoreOption: String = "overwriteIncompatibleStoreOption"
 
 /**
     Default options passed to attached and configure the persistent stores.
@@ -204,7 +204,7 @@ open class GenericCoreDataStack<CoordinatorType: NSPersistentStoreCoordinator, C
                 let storeWalPath = "\(storePath)-wal"
                 
                 // Check the store for compatibility if requested by developer.
-                if options?[OverwriteIncompatibleStoreOption] as? Bool == true {
+                if options?[overwriteIncompatibleStoreOption] as? Bool == true {
                     
                     logInfo(tag) { "Checking to see if persistent store is compatible with the model." }
                     

--- a/Tests/CoherenceTests/CoherenceTestUtilities.swift
+++ b/Tests/CoherenceTests/CoherenceTestUtilities.swift
@@ -1,0 +1,60 @@
+//
+//  CoherenceTestUtilities.swift
+//  Coherence
+//
+//  Created by Tony Stone on 10/31/16.
+//  Copyright © 2016 Tony Stone. All rights reserved.
+//
+
+import Foundation
+
+internal func cachesDirectory() throws -> URL {
+    
+    let fileManager = FileManager.default
+    
+    return try fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+}
+
+
+internal func removePersistentStoreCache() throws {
+    
+    let fileManager = FileManager.default
+    
+    let files = try fileManager.contentsOfDirectory(at: cachesDirectory(), includingPropertiesForKeys: [.nameKey], options: .skipsHiddenFiles)
+    
+    for file in files {
+        try fileManager.removeItem(at: file)
+    }
+}
+
+
+internal func persistentStoreExists(storePrefix: String, storeType: String,  configuration: String? = nil) throws -> Bool {
+    
+    let storePath = try cachesDirectory().appendingPathComponent("\(storePrefix)\(configuration ?? "").\(storeType)").path
+    
+    return FileManager.default.fileExists(atPath: storePath)
+}
+
+internal func deletePersistentStoreFilesIfExist(storePrefix: String, storeType: String,  configuration: String? = nil) throws {
+    
+    let storeDirectory = try cachesDirectory()
+    
+    let storePath = storeDirectory.appendingPathComponent("\(storePrefix)\(configuration ?? "").\(storeType)").path
+    
+    let storeShmPath = "\(storePath)-shm"
+    let storeWalPath = "\(storePath)-wal"
+    
+    try deleteIfExists(fileURL: URL(fileURLWithPath: storePath))
+    try deleteIfExists(fileURL: URL(fileURLWithPath: storeShmPath))
+    try deleteIfExists(fileURL: URL(fileURLWithPath: storeWalPath))
+}
+
+internal func deleteIfExists(fileURL url: URL) throws {
+    
+    let fileManager = FileManager.default
+    let path = url.path
+    
+    if fileManager.fileExists(atPath: path) {
+        try fileManager.removeItem(at: url)
+    }
+}

--- a/Tests/CoherenceTests/CoreDataStackTests.swift
+++ b/Tests/CoherenceTests/CoreDataStackTests.swift
@@ -66,7 +66,7 @@ class CoreDataStackTests: XCTestCase {
         let storePrefix                 = String(describing: TestModel1.self)
         var options: [AnyHashable: Any] = defaultStoreOptions
         
-        options[OverwriteIncompatibleStoreOption] = true
+        options[overwriteIncompatibleStoreOption] = true
         
         do {
             let _ = try CoreDataStack(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix, configurationOptions: [defaultModelConfigurationName: (storeType: NSSQLiteStoreType, storeOptions: options, migrationManager: nil)])

--- a/Tests/CoherenceTests/GenericCoreDataStackTests.swift
+++ b/Tests/CoherenceTests/GenericCoreDataStackTests.swift
@@ -183,8 +183,8 @@ class GenericCoreDataStackTests: XCTestCase {
         let prefix      = String(describing: type(of: model.self))
         let storeType   = NSSQLiteStoreType
         
-        // Initialize model 3 (no configurations), with model 1s name
-        let _ = try CoreDataStackType(managedObjectModel: TestModel3(), storeNamePrefix: prefix)
+        // Initialize model 2 (no configurations), with model 1s name
+        let _ = try CoreDataStackType(managedObjectModel: TestModel2(), storeNamePrefix: prefix)
         
         var options: [AnyHashable: Any] = defaultStoreOptions
         options[overwriteIncompatibleStoreOption] = true
@@ -261,4 +261,5 @@ class GenericCoreDataStackTests: XCTestCase {
             XCTFail()
         }
     }
+
 }

--- a/Tests/CoherenceTests/GenericCoreDataStackTests.swift
+++ b/Tests/CoherenceTests/GenericCoreDataStackTests.swift
@@ -78,6 +78,19 @@ class GenericCoreDataStackTests: XCTestCase {
         }
     }
     
+    func testConstruction_WithEmptyOptions() {
+        
+        let storePrefix = String(describing: TestModel1.self)
+        
+        do {
+            let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix, configurationOptions: [:])
+            
+            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType))
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
     func testConstruction_MultiConfiguration_SQLiteStoreType() throws {
         
         let storePrefix = String(describing: TestModel2.self)

--- a/Tests/CoherenceTests/GenericCoreDataStackTests.swift
+++ b/Tests/CoherenceTests/GenericCoreDataStackTests.swift
@@ -51,12 +51,13 @@ class GenericCoreDataStackTests: XCTestCase {
     
     func testConstruction() {
         
-        let storePrefix = String(describing: TestModel1.self)
+        let model  = TestModel1()
+        let prefix = String(describing: type(of: model.self))
         
         do {
-            let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix)
+            let _ = try CoreDataStackType(managedObjectModel: model, storeNamePrefix: prefix)
             
-            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: prefix, storeType: defaultStoreType))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -64,15 +65,17 @@ class GenericCoreDataStackTests: XCTestCase {
     
     func testConstruction_WithOptions() {
         
-        let storePrefix                 = String(describing: TestModel1.self)
+        let model  = TestModel1()
+        let prefix = String(describing: type(of: model.self))
+        
         var options: [AnyHashable: Any] = defaultStoreOptions
         
         options[OverwriteIncompatibleStoreOption] = true
         
         do {
-            let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix, configurationOptions: [defaultModelConfigurationName: (storeType: NSSQLiteStoreType, storeOptions: options, migrationManager: nil)])
+            let _ = try CoreDataStackType(managedObjectModel: model, storeNamePrefix: prefix, configurationOptions: [defaultModelConfigurationName: (storeType: NSSQLiteStoreType, storeOptions: options, migrationManager: nil)])
             
-            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: prefix, storeType: defaultStoreType))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -80,12 +83,13 @@ class GenericCoreDataStackTests: XCTestCase {
     
     func testConstruction_WithEmptyOptions() {
         
-        let storePrefix = String(describing: TestModel1.self)
+        let model  = TestModel1()
+        let prefix = String(describing: type(of: model.self))
         
         do {
-            let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix, configurationOptions: [:])
+            let _ = try CoreDataStackType(managedObjectModel: model, storeNamePrefix: prefix, configurationOptions: [:])
             
-            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: prefix, storeType: defaultStoreType))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -93,20 +97,21 @@ class GenericCoreDataStackTests: XCTestCase {
     
     func testConstruction_MultiConfiguration_SQLiteStoreType() throws {
         
-        let storePrefix = String(describing: TestModel2.self)
+        let model  = TestModel3()
+        let prefix = String(describing: type(of: model.self))
         
         var options: [AnyHashable: Any] = defaultStoreOptions
         options[OverwriteIncompatibleStoreOption] = true
         
         do {
             /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
-            let _ = try CoreDataStackType(managedObjectModel: TestModel2(),
-                                          storeNamePrefix: storePrefix,
+            let _ = try CoreDataStackType(managedObjectModel: model,
+                                          storeNamePrefix: prefix,
                                           configurationOptions: ["PersistentEntities": (storeType: NSSQLiteStoreType, storeOptions: options, migrationManager: nil),
                                                                  "TransientEntities":  (storeType: NSSQLiteStoreType, storeOptions: options, migrationManager: nil)])
             
-            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: NSSQLiteStoreType, configuration: "PersistentEntities"))
-            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: NSSQLiteStoreType, configuration: "TransientEntities"))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: prefix, storeType: NSSQLiteStoreType, configuration: "PersistentEntities"))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: prefix, storeType: NSSQLiteStoreType, configuration: "TransientEntities"))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -114,20 +119,21 @@ class GenericCoreDataStackTests: XCTestCase {
     
     func testConstruction_MultiConfiguration_InMemoryType() throws {
         
-        let storePrefix = String(describing: TestModel2.self)
+        let model  = TestModel3()
+        let prefix = String(describing: type(of: model.self))
         
         var options: [AnyHashable: Any] = defaultStoreOptions
         options[OverwriteIncompatibleStoreOption] = true
         
         do {
             /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
-            let _ = try CoreDataStackType(managedObjectModel: TestModel2(),
-                                          storeNamePrefix: storePrefix,
+            let _ = try CoreDataStackType(managedObjectModel: model,
+                                          storeNamePrefix: prefix,
                                           configurationOptions: ["PersistentEntities": (storeType: NSInMemoryStoreType, storeOptions: options, migrationManager: nil),
                                                                  "TransientEntities":  (storeType: NSInMemoryStoreType, storeOptions: options, migrationManager: nil)])
             
-            XCTAssertFalse(try persistentStoreExists(storePrefix: storePrefix, storeType: NSInMemoryStoreType, configuration: "PersistentEntities"))
-            XCTAssertFalse(try persistentStoreExists(storePrefix: storePrefix, storeType: NSInMemoryStoreType, configuration: "TransientEntities"))
+            XCTAssertFalse(try persistentStoreExists(storePrefix: prefix, storeType: NSInMemoryStoreType, configuration: "PersistentEntities"))
+            XCTAssertFalse(try persistentStoreExists(storePrefix: prefix, storeType: NSInMemoryStoreType, configuration: "TransientEntities"))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -135,20 +141,21 @@ class GenericCoreDataStackTests: XCTestCase {
     
     func testConstruction_MultiConfiguration_MixedType() throws {
         
-        let storePrefix = String(describing: TestModel2.self)
+        let model  = TestModel3()
+        let prefix = String(describing: type(of: model.self))
         
         var options: [AnyHashable: Any] = defaultStoreOptions
         options[OverwriteIncompatibleStoreOption] = true
         
         do {
             /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
-            let _ = try CoreDataStackType(managedObjectModel: TestModel2(),
-                                          storeNamePrefix: storePrefix,
+            let _ = try CoreDataStackType(managedObjectModel: model,
+                                          storeNamePrefix: prefix,
                                           configurationOptions: ["PersistentEntities": (storeType: NSSQLiteStoreType,   storeOptions: options, migrationManager: nil),
                                                                  "TransientEntities":  (storeType: NSInMemoryStoreType, storeOptions: options, migrationManager: nil)])
             
-            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix,  storeType: NSSQLiteStoreType,   configuration: "PersistentEntities"))
-            XCTAssertFalse(try persistentStoreExists(storePrefix: storePrefix, storeType: NSInMemoryStoreType, configuration: "TransientEntities"))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: prefix,  storeType: NSSQLiteStoreType,   configuration: "PersistentEntities"))
+            XCTAssertFalse(try persistentStoreExists(storePrefix: prefix, storeType: NSInMemoryStoreType, configuration: "TransientEntities"))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -156,14 +163,15 @@ class GenericCoreDataStackTests: XCTestCase {
     
     func testConstruction_MultiConfiguration_DefaultStoreType() throws {
         
-        let storePrefix = String(describing: TestModel2.self)
+        let model  = TestModel3()
+        let prefix = String(describing: type(of: model.self))
 
         do {
             /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
-            let _ = try CoreDataStackType(managedObjectModel: TestModel2(), storeNamePrefix: storePrefix)
+            let _ = try CoreDataStackType(managedObjectModel: model, storeNamePrefix: prefix)
             
-            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType, configuration: "PersistentEntities"))
-            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType, configuration: "TransientEntities"))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: prefix, storeType: defaultStoreType, configuration: "PersistentEntities"))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: prefix, storeType: defaultStoreType, configuration: "TransientEntities"))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -171,32 +179,34 @@ class GenericCoreDataStackTests: XCTestCase {
     
     func testStackCreation_OverrideStoreIfModelIncompatible() throws {
         
-        let storePrefix = String(describing: TestModel1.self)
+        let model       = TestModel1()
+        let prefix      = String(describing: type(of: model.self))
         let storeType   = NSSQLiteStoreType
         
         // Initialize model 3 (no configurations), with model 1s name
-        let _ = try CoreDataStackType(managedObjectModel: TestModel3(), storeNamePrefix: storePrefix)
+        let _ = try CoreDataStackType(managedObjectModel: TestModel3(), storeNamePrefix: prefix)
         
         var options: [AnyHashable: Any] = defaultStoreOptions
         options[OverwriteIncompatibleStoreOption] = true
 
         // Now use model 1 with model 1s name
-        let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix, configurationOptions: [defaultModelConfigurationName: (storeType: storeType, storeOptions: options, migrationManager: nil)])
+        let _ = try CoreDataStackType(managedObjectModel: model, storeNamePrefix: prefix, configurationOptions: [defaultModelConfigurationName: (storeType: storeType, storeOptions: options, migrationManager: nil)])
         
-        XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: storeType, configuration: nil))
+        XCTAssertTrue(try persistentStoreExists(storePrefix: prefix, storeType: storeType, configuration: nil))
     }
     
     func testConstruction_WithAsyncErrorHandler() {
         
-        let storePrefix = String(describing: TestModel1.self)
+        let model  = TestModel1()
+        let prefix = String(describing: type(of: model.self))
         
         do {
-            let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix, asyncErrorBlock: { (error) -> Void in
+            let _ = try CoreDataStackType(managedObjectModel: model, storeNamePrefix: prefix, asyncErrorBlock: { (error) -> Void in
                 // Async Error block
                 print(error.localizedDescription)
             })
             
-            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: prefix, storeType: defaultStoreType))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -204,7 +214,10 @@ class GenericCoreDataStackTests: XCTestCase {
     
     func testCRUD () throws {
         
-        let coreDataStack = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: String(describing: TestModel1.self))
+        let model  = TestModel1()
+        let prefix = String(describing: type(of: model.self))
+        
+        let coreDataStack = try CoreDataStackType(managedObjectModel: model, storeNamePrefix: prefix)
         
         let editContext       = coreDataStack.editContext()
         let mainThreadContext = coreDataStack.mainThreadContext()

--- a/Tests/CoherenceTests/GenericCoreDataStackTests.swift
+++ b/Tests/CoherenceTests/GenericCoreDataStackTests.swift
@@ -70,7 +70,7 @@ class GenericCoreDataStackTests: XCTestCase {
         
         var options: [AnyHashable: Any] = defaultStoreOptions
         
-        options[OverwriteIncompatibleStoreOption] = true
+        options[overwriteIncompatibleStoreOption] = true
         
         do {
             let _ = try CoreDataStackType(managedObjectModel: model, storeNamePrefix: prefix, configurationOptions: [defaultModelConfigurationName: (storeType: NSSQLiteStoreType, storeOptions: options, migrationManager: nil)])
@@ -101,7 +101,7 @@ class GenericCoreDataStackTests: XCTestCase {
         let prefix = String(describing: type(of: model.self))
         
         var options: [AnyHashable: Any] = defaultStoreOptions
-        options[OverwriteIncompatibleStoreOption] = true
+        options[overwriteIncompatibleStoreOption] = true
         
         do {
             /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
@@ -123,7 +123,7 @@ class GenericCoreDataStackTests: XCTestCase {
         let prefix = String(describing: type(of: model.self))
         
         var options: [AnyHashable: Any] = defaultStoreOptions
-        options[OverwriteIncompatibleStoreOption] = true
+        options[overwriteIncompatibleStoreOption] = true
         
         do {
             /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
@@ -145,7 +145,7 @@ class GenericCoreDataStackTests: XCTestCase {
         let prefix = String(describing: type(of: model.self))
         
         var options: [AnyHashable: Any] = defaultStoreOptions
-        options[OverwriteIncompatibleStoreOption] = true
+        options[overwriteIncompatibleStoreOption] = true
         
         do {
             /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
@@ -187,7 +187,7 @@ class GenericCoreDataStackTests: XCTestCase {
         let _ = try CoreDataStackType(managedObjectModel: TestModel3(), storeNamePrefix: prefix)
         
         var options: [AnyHashable: Any] = defaultStoreOptions
-        options[OverwriteIncompatibleStoreOption] = true
+        options[overwriteIncompatibleStoreOption] = true
 
         // Now use model 1 with model 1s name
         let _ = try CoreDataStackType(managedObjectModel: model, storeNamePrefix: prefix, configurationOptions: [defaultModelConfigurationName: (storeType: storeType, storeOptions: options, migrationManager: nil)])

--- a/Tests/CoherenceTests/GenericCoreDataStackTests.swift
+++ b/Tests/CoherenceTests/GenericCoreDataStackTests.swift
@@ -186,6 +186,22 @@ class GenericCoreDataStackTests: XCTestCase {
         XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: storeType, configuration: nil))
     }
     
+    func testConstruction_WithAsyncErrorHandler() {
+        
+        let storePrefix = String(describing: TestModel1.self)
+        
+        do {
+            let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix, asyncErrorBlock: { (error) -> Void in
+                // Async Error block
+                print(error.localizedDescription)
+            })
+            
+            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType))
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
     func testCRUD () throws {
         
         let coreDataStack = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: String(describing: TestModel1.self))

--- a/Tests/CoherenceTests/GenericCoreDataStackTests.swift
+++ b/Tests/CoherenceTests/GenericCoreDataStackTests.swift
@@ -1,0 +1,222 @@
+///
+///  GenericCoreDataStackTests.swift
+///
+///  Copyright 2016 The Climate Corporation
+///  Copyright 2016 Tony Stone
+///
+///  Licensed under the Apache License, Version 2.0 (the "License");
+///  you may not use this file except in compliance with the License.
+///  You may obtain a copy of the License at
+///
+///  http://www.apache.org/licenses/LICENSE-2.0
+///
+///  Unless required by applicable law or agreed to in writing, software
+///  distributed under the License is distributed on an "AS IS" BASIS,
+///  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///  See the License for the specific language governing permissions and
+///  limitations under the License.
+///
+///  Created by Tony Stone on 10/31/16.
+///
+import XCTest
+import CoreData
+import Coherence
+
+fileprivate let firstName = "First"
+fileprivate let lastName  = "Last"
+fileprivate let userName  = "First Last"
+
+class GenericCoreDataStackTests: XCTestCase {
+
+    fileprivate typealias CoreDataStackType = GenericCoreDataStack<NSPersistentStoreCoordinator, NSManagedObjectContext>
+
+    override func setUp() {
+        super.setUp()
+        
+        do {
+            try removePersistentStoreCache()
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
+    override func tearDown() {
+        do {
+            try removePersistentStoreCache()
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+        super.tearDown()
+    }
+    
+    func testConstruction() {
+        
+        let storePrefix = String(describing: TestModel1.self)
+        
+        do {
+            let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix)
+            
+            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType))
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
+    func testConstruction_WithOptions() {
+        
+        let storePrefix                 = String(describing: TestModel1.self)
+        var options: [AnyHashable: Any] = defaultStoreOptions
+        
+        options[OverwriteIncompatibleStoreOption] = true
+        
+        do {
+            let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix, configurationOptions: [defaultModelConfigurationName: (storeType: NSSQLiteStoreType, storeOptions: options, migrationManager: nil)])
+            
+            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType))
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
+    func testConstruction_MultiConfiguration_SQLiteStoreType() throws {
+        
+        let storePrefix = String(describing: TestModel2.self)
+        
+        var options: [AnyHashable: Any] = defaultStoreOptions
+        options[OverwriteIncompatibleStoreOption] = true
+        
+        do {
+            /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
+            let _ = try CoreDataStackType(managedObjectModel: TestModel2(),
+                                          storeNamePrefix: storePrefix,
+                                          configurationOptions: ["PersistentEntities": (storeType: NSSQLiteStoreType, storeOptions: options, migrationManager: nil),
+                                                                 "TransientEntities":  (storeType: NSSQLiteStoreType, storeOptions: options, migrationManager: nil)])
+            
+            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: NSSQLiteStoreType, configuration: "PersistentEntities"))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: NSSQLiteStoreType, configuration: "TransientEntities"))
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
+    func testConstruction_MultiConfiguration_InMemoryType() throws {
+        
+        let storePrefix = String(describing: TestModel2.self)
+        
+        var options: [AnyHashable: Any] = defaultStoreOptions
+        options[OverwriteIncompatibleStoreOption] = true
+        
+        do {
+            /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
+            let _ = try CoreDataStackType(managedObjectModel: TestModel2(),
+                                          storeNamePrefix: storePrefix,
+                                          configurationOptions: ["PersistentEntities": (storeType: NSInMemoryStoreType, storeOptions: options, migrationManager: nil),
+                                                                 "TransientEntities":  (storeType: NSInMemoryStoreType, storeOptions: options, migrationManager: nil)])
+            
+            XCTAssertFalse(try persistentStoreExists(storePrefix: storePrefix, storeType: NSInMemoryStoreType, configuration: "PersistentEntities"))
+            XCTAssertFalse(try persistentStoreExists(storePrefix: storePrefix, storeType: NSInMemoryStoreType, configuration: "TransientEntities"))
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
+    func testConstruction_MultiConfiguration_MixedType() throws {
+        
+        let storePrefix = String(describing: TestModel2.self)
+        
+        var options: [AnyHashable: Any] = defaultStoreOptions
+        options[OverwriteIncompatibleStoreOption] = true
+        
+        do {
+            /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
+            let _ = try CoreDataStackType(managedObjectModel: TestModel2(),
+                                          storeNamePrefix: storePrefix,
+                                          configurationOptions: ["PersistentEntities": (storeType: NSSQLiteStoreType,   storeOptions: options, migrationManager: nil),
+                                                                 "TransientEntities":  (storeType: NSInMemoryStoreType, storeOptions: options, migrationManager: nil)])
+            
+            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix,  storeType: NSSQLiteStoreType,   configuration: "PersistentEntities"))
+            XCTAssertFalse(try persistentStoreExists(storePrefix: storePrefix, storeType: NSInMemoryStoreType, configuration: "TransientEntities"))
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
+    func testConstruction_MultiConfiguration_DefaultStoreType() throws {
+        
+        let storePrefix = String(describing: TestModel2.self)
+
+        do {
+            /// TestModel2 has multiple configurations and should will produce multiple persistent stores.
+            let _ = try CoreDataStackType(managedObjectModel: TestModel2(), storeNamePrefix: storePrefix)
+            
+            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType, configuration: "PersistentEntities"))
+            XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: defaultStoreType, configuration: "TransientEntities"))
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
+    func testStackCreation_OverrideStoreIfModelIncompatible() throws {
+        
+        let storePrefix = String(describing: TestModel1.self)
+        let storeType   = NSSQLiteStoreType
+        
+        // Initialize model 3 (no configurations), with model 1s name
+        let _ = try CoreDataStackType(managedObjectModel: TestModel3(), storeNamePrefix: storePrefix)
+        
+        var options: [AnyHashable: Any] = defaultStoreOptions
+        options[OverwriteIncompatibleStoreOption] = true
+
+        // Now use model 1 with model 1s name
+        let _ = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: storePrefix, configurationOptions: [defaultModelConfigurationName: (storeType: storeType, storeOptions: options, migrationManager: nil)])
+        
+        XCTAssertTrue(try persistentStoreExists(storePrefix: storePrefix, storeType: storeType, configuration: nil))
+    }
+    
+    func testCRUD () throws {
+        
+        let coreDataStack = try CoreDataStackType(managedObjectModel: TestModel1(), storeNamePrefix: String(describing: TestModel1.self))
+        
+        let editContext       = coreDataStack.editContext()
+        let mainThreadContext = coreDataStack.mainThreadContext()
+        
+        var userId: NSManagedObjectID? = nil
+        
+        editContext.performAndWait {
+            
+            if let insertedUser = NSEntityDescription.insertNewObject(forEntityName: "User", into:editContext) as? User {
+                
+                insertedUser.firstName = firstName
+                insertedUser.lastName  = lastName
+                insertedUser.userName  = userName
+                
+                do {
+                    try editContext.save()
+                } catch {
+                    XCTFail()
+                }
+                userId = insertedUser.objectID
+            }
+        }
+        
+        var savedUser: NSManagedObject? = nil
+        
+        mainThreadContext.performAndWait {
+            if let userId = userId {
+                savedUser = mainThreadContext.object(with: userId)
+            }
+        }
+        
+        XCTAssertNotNil(savedUser)
+        
+        if let savedUser = savedUser as? User {
+            
+            XCTAssertTrue(savedUser.firstName == firstName)
+            XCTAssertTrue(savedUser.lastName  == lastName)
+            XCTAssertTrue(savedUser.userName  == userName)
+            
+        } else {
+            XCTFail()
+        }
+    }
+}

--- a/Tests/CoherenceTests/TestModel1.swift
+++ b/Tests/CoherenceTests/TestModel1.swift
@@ -27,9 +27,8 @@ internal class TestModel1: NSManagedObjectModel {
         super.init()
         
         let userEntity = self.userEntity()
-        let roleEntity = self.roleEntity()
         
-        self.entities = [userEntity, roleEntity]
+        self.entities = [userEntity]
         
         self.versionIdentifiers = [1]
     }
@@ -63,26 +62,6 @@ internal class TestModel1: NSManagedObjectModel {
         let entity = NSEntityDescription()
         entity.name = "User"
         entity.managedObjectClassName = "User"
-        
-        entity.properties = attributes
-        
-        return entity;
-    }
-    
-    fileprivate func roleEntity() -> NSEntityDescription {
-        
-        var attributes = [NSAttributeDescription]()
-        
-        let attribute = NSAttributeDescription()
-        attribute.name = "name"
-        attribute.isOptional = false
-        attribute.attributeType = NSAttributeType.stringAttributeType
-        attributes.append(attribute)
-        
-        
-        let entity = NSEntityDescription()
-        entity.name = "Role"
-        entity.managedObjectClassName = "NSManagedObject"
         
         entity.properties = attributes
         

--- a/Tests/CoherenceTests/TestModel2.swift
+++ b/Tests/CoherenceTests/TestModel2.swift
@@ -31,9 +31,6 @@ internal class TestModel2: NSManagedObjectModel {
         
         self.entities = [userEntity, roleEntity]
         
-        self.setEntities([userEntity], forConfigurationName: "PersistentEntities")
-        self.setEntities([userEntity], forConfigurationName: "TransientEntities")
-        
         self.versionIdentifiers = [2]
     }
     

--- a/Tests/CoherenceTests/TestModel2.swift
+++ b/Tests/CoherenceTests/TestModel2.swift
@@ -26,36 +26,75 @@ internal class TestModel2: NSManagedObjectModel {
     override init() {
         super.init()
         
-        self.entities = [self.simpleEntity()]
-        self.versionIdentifiers = [1]
+        let userEntity = self.userEntity()
+        let roleEntity = self.roleEntity()
+        
+        self.entities = [userEntity, roleEntity]
+        
+        self.setEntities([userEntity], forConfigurationName: "PersistentEntities")
+        self.setEntities([userEntity], forConfigurationName: "TransientEntities")
+        
+        self.versionIdentifiers = [2]
     }
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
     
-    fileprivate func simpleEntity() -> NSEntityDescription {
+    fileprivate func userEntity() -> NSEntityDescription {
         
         var attributes = [NSAttributeDescription]()
         
-        let userId = NSAttributeDescription()
-        userId.name = "userId"
-        userId.isOptional = false
-        userId.attributeType = NSAttributeType.integer32AttributeType
-        attributes.append(userId)
+        var attribute = NSAttributeDescription()
+        attribute.name = "firstName"
+        attribute.isOptional = true
+        attribute.attributeType = NSAttributeType.stringAttributeType
+        attributes.append(attribute)
         
-        let transactionID = NSAttributeDescription()
-        transactionID.name = "transactionID"
-        transactionID.isOptional = false
-        transactionID.attributeType = NSAttributeType.stringAttributeType
-        attributes.append(transactionID)
+        attribute = NSAttributeDescription()
+        attribute.name = "lastName"
+        attribute.isOptional = true
+        attribute.attributeType = NSAttributeType.stringAttributeType
+        attributes.append(attribute)
+        
+        attribute = NSAttributeDescription()
+        attribute.name = "userName"
+        attribute.isOptional = false
+        attribute.attributeType = NSAttributeType.stringAttributeType
+        attributes.append(attribute)
         
         let entity = NSEntityDescription()
-        entity.name = "SimpleEntity"
-        entity.managedObjectClassName = "SimpleEntity"
+        entity.name = "User"
+        entity.managedObjectClassName = "User"
+        
+        entity.properties = attributes
+        
+        return entity;
+    }
+    
+    fileprivate func roleEntity() -> NSEntityDescription {
+        
+        var attributes = [NSAttributeDescription]()
+        
+        var attribute = NSAttributeDescription()
+        attribute.name = "name"
+        attribute.isOptional = false
+        attribute.attributeType = NSAttributeType.stringAttributeType
+        attributes.append(attribute)
+        
+        attribute = NSAttributeDescription()
+        attribute.name = "description"
+        attribute.isOptional = true
+        attribute.attributeType = NSAttributeType.stringAttributeType
+        attributes.append(attribute)
+        
+        let entity = NSEntityDescription()
+        entity.name = "Role"
+        entity.managedObjectClassName = "NSManagedObject"
         
         entity.properties = attributes
         
         return entity;
     }
 }
+

--- a/Tests/CoherenceTests/TestModel3.swift
+++ b/Tests/CoherenceTests/TestModel3.swift
@@ -1,7 +1,6 @@
 ///
-///  TestModel1.swift
+///  TestModel3.swift
 ///
-///  Copyright 2016 The Climate Corporation
 ///  Copyright 2016 Tony Stone
 ///
 ///  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,20 +15,19 @@
 ///  See the License for the specific language governing permissions and
 ///  limitations under the License.
 ///
-///  Created by Tony Stone on 10/30/16.
+///  Created by Tony Stone on 10/31/16.
 ///
 import Foundation
 import CoreData
 
-internal class TestModel1: NSManagedObjectModel {
+internal class TestModel3: NSManagedObjectModel {
     
     override init() {
         super.init()
         
         let userEntity = self.userEntity()
-        let roleEntity = self.roleEntity()
         
-        self.entities = [userEntity, roleEntity]
+        self.entities = [userEntity]
         
         self.versionIdentifiers = [1]
     }
@@ -69,24 +67,4 @@ internal class TestModel1: NSManagedObjectModel {
         return entity;
     }
     
-    fileprivate func roleEntity() -> NSEntityDescription {
-        
-        var attributes = [NSAttributeDescription]()
-        
-        let attribute = NSAttributeDescription()
-        attribute.name = "name"
-        attribute.isOptional = false
-        attribute.attributeType = NSAttributeType.stringAttributeType
-        attributes.append(attribute)
-        
-        
-        let entity = NSEntityDescription()
-        entity.name = "Role"
-        entity.managedObjectClassName = "NSManagedObject"
-        
-        entity.properties = attributes
-        
-        return entity;
-    }
 }
-

--- a/Tests/CoherenceTests/TestModel3.swift
+++ b/Tests/CoherenceTests/TestModel3.swift
@@ -26,10 +26,14 @@ internal class TestModel3: NSManagedObjectModel {
         super.init()
         
         let userEntity = self.userEntity()
+        let roleEntity = self.roleEntity()
         
-        self.entities = [userEntity]
+        self.entities = [userEntity, roleEntity]
         
-        self.versionIdentifiers = [1]
+        self.setEntities([userEntity], forConfigurationName: "PersistentEntities")
+        self.setEntities([userEntity], forConfigurationName: "TransientEntities")
+        
+        self.versionIdentifiers = [3]
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -66,5 +70,31 @@ internal class TestModel3: NSManagedObjectModel {
         
         return entity;
     }
+    
+    fileprivate func roleEntity() -> NSEntityDescription {
+        
+        var attributes = [NSAttributeDescription]()
+        
+        var attribute = NSAttributeDescription()
+        attribute.name = "name"
+        attribute.isOptional = false
+        attribute.attributeType = NSAttributeType.stringAttributeType
+        attributes.append(attribute)
+        
+        attribute = NSAttributeDescription()
+        attribute.name = "description"
+        attribute.isOptional = true
+        attribute.attributeType = NSAttributeType.stringAttributeType
+        attributes.append(attribute)
+        
+        let entity = NSEntityDescription()
+        entity.name = "Role"
+        entity.managedObjectClassName = "NSManagedObject"
+        
+        entity.properties = attributes
+        
+        return entity;
+    }
+
     
 }


### PR DESCRIPTION
- Adding GenericCoreDataStackTests.swift with coverage for configurations and various combinations of the default store type.
- Added CoherenceTestUtilitites.swift to store shared funcs for tests.
- Updated CoreDataStackTests.swift adding setup and tearDown to removed test persistent stores.
- Updated TestModel1 and TestModel2 to add configurations to TestModel2.